### PR TITLE
Adding another option for GET endpoints

### DIFF
--- a/generators/api/index.js
+++ b/generators/api/index.js
@@ -127,6 +127,17 @@ module.exports = yeoman.Base.extend({
       when: function (props) {
         return props.storeUser;
       }
+    }, {
+      type: 'confirm',
+      name: 'getList',
+      message: 'Do you want the retrieve methods (GET) to have the form { rows, count } ?',
+      default: false,
+      when: function (props) {
+        var methods = getSelectedMethods(props);
+        return methods.find(function (method) {
+          return method.value === 'GET LIST';
+        }) && props.generateModel;
+      }
     }];
 
     return this.prompt(prompts).then(function (props) {
@@ -149,6 +160,7 @@ module.exports = yeoman.Base.extend({
           return field.trim();
         }) : [];
 
+      this.props.getList = props.getList || false;
       this.props.storeUser = this.props.storeUser || false;
 
       if (props.userField && this.props.modelFields.indexOf(props.userField) !== -1) {

--- a/generators/api/templates/controller.js
+++ b/generators/api/templates/controller.js
@@ -1,5 +1,4 @@
 <%_ if (generateModel && methods.length) { _%>
-import _ from 'lodash'
 import { success, notFound<% if (storeUser && (userMethods.indexOf('PUT') !== -1 || userMethods.indexOf('DELETE') !== -1)) { %>, authorOrAdmin<% } %> } from '../../services/response/'
 import { <%= pascal %> } from '.'
 <%_ } _%>
@@ -22,7 +21,20 @@ export const create = ({ <%= storeUser ? 'user, ' : '' %><%- modelFields.length 
 <%_ if (methods.indexOf('GET LIST') !== -1) { _%>
 
 export const index = ({ querymen: { query, select, cursor } }, res, next) =>
-  <%_ if (generateModel) { _%>
+  <%_ if (generateModel) { if (getList) { _%>
+  <%= pascal %>.count()
+    .then(count => <%= pascal %>.find(query, select, cursor)
+      <%_ if (storeUser) { _%>
+      .populate('<%= userField %>')
+      <%_ } _%>
+      .then((<%= camels %>) => ({
+        count,
+        rows: <%= camels %>.map((<%= camel %>) => <%= camel %>.view())
+      }))
+    )
+    .then(success(res))
+    .catch(next)
+  <%_ } else { _%>
   <%= pascal %>.find(query, select, cursor)
     <%_ if (storeUser) { _%>
     .populate('<%= userField %>')
@@ -30,7 +42,7 @@ export const index = ({ querymen: { query, select, cursor } }, res, next) =>
     .then((<%= camels %>) => <%= camels %>.map((<%= camel %>) => <%= camel %>.view()))
     .then(success(res))
     .catch(next)
-  <%_ } else { _%>
+  <%_ } } else { _%>
   res.status(200).json([])
   <%_ } _%>
 <%_ } _%>
@@ -64,7 +76,7 @@ export const update = ({ <%=
     <%_ if (storeUser && userMethods.indexOf('PUT') !== -1) { _%>
     .then(authorOrAdmin(res, user, '<%= userField %>'))
     <%_ } _%>
-    .then((<%= camel %>) => <%= camel %> ? _.merge(<%= camel %>, body).save() : null)
+    .then((<%= camel %>) => <%= camel %> ? Object.assign(<%= camel %>, body).save() : null)
     .then((<%= camel %>) => <%= camel %> ? <%= camel %>.view(true) : null)
     .then(success(res))
     .catch(next)

--- a/generators/api/templates/index.js
+++ b/generators/api/templates/index.js
@@ -73,7 +73,12 @@ const { <%= modelFields.join(', ') %> } = schema.tree
  <%_ } _%>
  <%_ if (method.method === 'GET LIST') { _%>
  * @apiUse listParams
+ <%_ if (getList) { _%>
+ * @apiSuccess {Number} count Total amount of <%= lowers %>.
+ * @apiSuccess {Object[]} rows List of <%= lowers %>.
+ <%_ } else { _%>
  * @apiSuccess {Object[]} <%= camels %> List of <%= lowers %>.
+ <%_ } _%>
  * @apiError {Object} 400 Some parameters may contain invalid values.
  <%_ } else if (method.method === 'DELETE') { _%>
  * @apiSuccess (Success 204) 204 No Content.

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -71,6 +71,14 @@ module.exports = yeoman.Base.extend({
       when: function (props) {
         return props.passwordReset;
       }
+    }, {
+      type: 'confirm',
+      name: 'getList',
+      message: 'Do you want the retrieve methods from users (GET) to have the form { rows, count } ?',
+      default: false,
+      when: function (props) {
+        return props.authMethods;
+      }
     }]).then(function (props) {
       that.props = props;
       that.props.slug = _.kebabCase(that.props.name);

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -61,7 +61,6 @@
     <%_ if (generateAuthApi) { _%>
     "jsonwebtoken": "^7.1.9",
     <%_ } _%>
-    "lodash": "^4.13.1",
     "mongoose": "^4.4.19",
     "mongoose-create-unique": "^0.4.1",
     "mongoose-keywords": "^0.3.1",

--- a/generators/app/templates/api/user/controller.js
+++ b/generators/app/templates/api/user/controller.js
@@ -1,12 +1,23 @@
-import _ from 'lodash'
 import { success, notFound } from '../../services/response/'
 import { User } from '.'
 
 export const index = ({ querymen: { query, select, cursor } }, res, next) =>
+<%_ if (getList) { _%>
+  User.count()
+    .then(count => User.find(query, select, cursor)
+      .then(users => ({
+        rows: users.map((user) => user.view()),
+        count
+      }))
+    )
+    .then(success(res))
+    .catch(next)
+<%_ } else { _%>
   User.find(query, select, cursor)
     .then((users) => users.map((user) => user.view()))
     .then(success(res))
     .catch(next)
+<%_ } _%>
 
 export const show = ({ params }, res, next) =>
   User.findById(params.id)
@@ -51,7 +62,7 @@ export const update = ({ bodymen: { body }, params, user }, res, next) =>
       }
       return result
     })
-    .then((user) => user ? _.merge(user, body).save() : null)
+    .then((user) => user ? Object.assign(user, body).save() : null)
     .then((user) => user ? user.view(true) : null)
     .then(success(res))
     .catch(next)

--- a/generators/app/templates/api/user/index.test.js
+++ b/generators/app/templates/api/user/index.test.js
@@ -22,7 +22,12 @@ test('GET /users 200 (admin)', async () => {
     .get('/')
     .query({ access_token: adminSession })
   expect(status).toBe(200)
+  <%_ if (getList) { _%>
+  expect(Array.isArray(body.rows)).toBe(true)
+  expect(Number.isNaN(body.count)).toBe(false)
+  <%_ } else { _%>
   expect(Array.isArray(body)).toBe(true)
+  <%_ } _%>
 })
 
 test('GET /users?page=2&limit=1 200 (admin)', async () => {
@@ -30,8 +35,14 @@ test('GET /users?page=2&limit=1 200 (admin)', async () => {
     .get('/')
     .query({ access_token: adminSession, page: 2, limit: 1 })
   expect(status).toBe(200)
+  <%_ if (getList) { _%>
+  expect(Array.isArray(body.rows)).toBe(true)
+  expect(Number.isNaN(body.count)).toBe(false)
+  expect(body.rows.length).toBe(1)
+  <%_ } else { _%>
   expect(Array.isArray(body)).toBe(true)
   expect(body.length).toBe(1)
+  <%_ } _%>
 })
 
 test('GET /users?q=user 200 (admin)', async () => {
@@ -39,8 +50,14 @@ test('GET /users?q=user 200 (admin)', async () => {
     .get('/')
     .query({ access_token: adminSession, q: 'user' })
   expect(status).toBe(200)
+  <%_ if (getList) { _%>
+  expect(Array.isArray(body.rows)).toBe(true)
+  expect(Number.isNaN(body.count)).toBe(false)
+  expect(body.rows.length).toBe(2)
+  <%_ } else { _%>
   expect(Array.isArray(body)).toBe(true)
   expect(body.length).toBe(2)
+  <%_ } _%>
 })
 
 test('GET /users?fields=name 200 (admin)', async () => {
@@ -48,8 +65,14 @@ test('GET /users?fields=name 200 (admin)', async () => {
     .get('/')
     .query({ access_token: adminSession, fields: 'name' })
   expect(status).toBe(200)
+  <%_ if (getList) { _%>
+  expect(Array.isArray(body.rows)).toBe(true)
+  expect(Number.isNaN(body.count)).toBe(false)
+  expect(Object.keys(body.rows[0])).toEqual(['id', 'name'])
+  <%_ } else { _%>
   expect(Array.isArray(body)).toBe(true)
   expect(Object.keys(body[0])).toEqual(['id', 'name'])
+  <%_ } _%>
 })
 
 test('GET /users 401 (user)', async () => {

--- a/generators/app/templates/src/app.js
+++ b/generators/app/templates/src/app.js
@@ -8,6 +8,7 @@ const app = express(api)
 const server = http.createServer(app)
 
 mongoose.connect(mongo.uri)
+mongoose.Promise = Promise
 
 setImmediate(() => {
   server.listen(port, ip, () => {

--- a/generators/app/templates/src/config.js
+++ b/generators/app/templates/src/config.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-unused-vars */
 import path from 'path'
-import _ from 'lodash'
 
 /* istanbul ignore next */
 const requireProcessEnv = (name) => {
@@ -68,5 +67,5 @@ const config = {
   }
 }
 
-module.exports = _.merge(config.all, config[config.all.env])
+module.exports = Object.assign(config.all, config[config.all.env])
 export default module.exports

--- a/test/index.js
+++ b/test/index.js
@@ -36,6 +36,8 @@ function install(answers, done, generateApis) {
           return apiWithModelFields(dir);
         }).then(function (dir) {
           return apiWithUserModelField(dir);
+        }).then(function (dir) {
+          return apiWithCountAndRowsGetList(dir);
         });
       }
 
@@ -137,6 +139,13 @@ function apiWithUserModelField(dir) {
   }, dir);
 }
 
+function apiWithCountAndRowsGetList(dir) {
+  return api({
+    kebab: 'count-and-rows-get-list',
+    getList: true
+  }, dir);
+}
+
 function api(answers, dir) {
   return helpers.run(path.join(__dirname, '../generators/api'))
     .inTmpDir(function (tmpDir) {
@@ -190,6 +199,13 @@ describe('generator-rest', function () {
   describe('install without auth API', function () {
     before(function (done) {
       install({generateAuthApi: false}, done, true);
+    });
+    it('should install and pass tests', function () {});
+  });
+
+  describe('install with { rows, count } API', function () {
+    before(function (done) {
+      install({getList: true}, done, true);
     });
     it('should install and pass tests', function () {});
   });


### PR DESCRIPTION
For my apps I'd like to have the GET methods return a `{ count, rows }` object so I can create paginations easily.

Also, removed lodash from the generated project since we can use the `Object.assign` method. where lodash was used