### PR TITLE
mongo connection warning removed with useMongoClient()

### DIFF
--- a/generators/app/templates/src/app.js
+++ b/generators/app/templates/src/app.js
@@ -7,7 +7,7 @@ import api from './api'
 const app = express(apiRoot, api)
 const server = http.createServer(app)
 
-mongoose.connect(mongo.uri)
+mongoose.connect(mongo.uri, { useMongoClient: true })
 mongoose.Promise = Promise
 
 setImmediate(() => {


### PR DESCRIPTION
Solved https://github.com/diegohaz/rest/issues/96 with the use of useMongoClient argument while initialization.