### PR TITLE
fix: fix tests failed error

### DIFF
--- a/generators/app/templates/test/setup.js
+++ b/generators/app/templates/test/setup.js
@@ -26,7 +26,7 @@ let mongoServer
 beforeAll(async () => {
   mongoServer = new MongodbMemoryServer()
   const mongoUri = await mongoServer.getUri()
-  await mongoose.connect(mongoUri, (err) => {
+  await mongoose.connect(mongoUri, undefined, (err) => {
     if (err) console.error(err)
   })
 })


### PR DESCRIPTION
Closes #240

Second parameter of mongoose.connect should be the opts, if no specific opts needed, pass undefined. Otherwise we will get following error:
![image](https://user-images.githubusercontent.com/7602106/106988372-9a8d8800-67aa-11eb-9ea7-f24ccf9a8d51.png)
